### PR TITLE
Change globals to match usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
   "env": {
-    "browser": true,
-    "jquery": true
+    "browser": true
   },
   "globals": {
     "uoe": true

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
     "browser": true
   },
   "globals": {
-    "uoe": true
+    "uoe": true,
+    "Handlebars": true
   },
   "rules": {
     "eqeqeq": "error",


### PR DESCRIPTION
Two changes to globals to be more relevant to our usage:
- Remove jQuery as a global, since we should all be using `uoe.$`
- Add Handlebars as a global, as it is now being adopted across multiple projects
