### PR TITLE
Added `no-restricted-globals`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,6 +52,7 @@
     "semi": "error",
     "valid-typeof": "error",
     "no-multi-str": "error",
+    "no-restricted-globals": ["error", "event"],
 
     "require-jsdoc": "warn",
     "no-invalid-this": "warn",


### PR DESCRIPTION
We discovered a bug in the DPT editor today caused by mistakenly using `window.event`. In IE and Chrome, `window.event` contains the event details for the _currently executing_  event, and I was doing something like this:
```javascript
$('a').on('click', function() {
  console.log(event.currentTarget);
});
```
This would log the `<a />` that was clicked. However, this is a non-standard feature and not supported in Firefox, where `window.event` is undefined and I get the error "event is not defined". Instead, I can access the event from the first parameter of the callback:
```javascript
$('a').on('click', function(event) {
  console.log(event.currentTarget);
});
```
This works cross-browser, and is properly standards-compliant, so is the preferred option. Generally, I've been doing this but ESLint considers `event` a valid global, so in one file where I hadn't defined event in the callback parameters, it wasn't picked up and so slipped through, broke in TRN, etc.

To fix all this, I want to add the following to our `.eslintrc` file: `"no-restricted-globals": ["error", "event"]`. This will throw an ESLint error whenever `window.event` is used.